### PR TITLE
fix: params order to match php implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,8 +173,8 @@ function hash(password, options) {
         id: `argon2${variant}`,
         version,
         params: {
-          t: iterations,
           m: memory,
+          t: iterations,
           p: parallelism
         },
         salt,


### PR DESCRIPTION
Problem: PHP Argon2 doesn't support parameter swapping.

PS. Not sure but this fixed the issue.